### PR TITLE
Replace functions with forward-line

### DIFF
--- a/SmoothScroll.el
+++ b/SmoothScroll.el
@@ -2,17 +2,23 @@
 ; use C-, to scroll up, C-. to scroll down
 
 ; author: Petr Glotov
+; modifiled: Takaaki Ishikawa
+
+(defvar smoothscroll-sticked-point (current-column))
+(run-with-idle-timer
+ 0.5 t '(lambda () (setq smoothscroll-sticked-point (current-column))))
 
 (defun scroll-one-down ()
   (interactive)
   (scroll-down 1)
   (forward-line -1)
-)
-(global-set-key [(control ?,)] 'scroll-one-down)
+  (move-to-column smoothscroll-sticked-point))
 
 (defun scroll-one-up ()
   (interactive)
   (scroll-up 1)
   (forward-line 1)
-)
+  (move-to-column smoothscroll-sticked-point))
+
+(global-set-key [(control ?,)] 'scroll-one-down)
 (global-set-key [(control ?.)] 'scroll-one-up)


### PR DESCRIPTION
When I byte-compled this useful elisp, I got warnings (see below).
I therefore replaced them with `forward-line'.

---

In scroll-one-down:
SmoothScroll.el:8 :4 :Warning: `previous-line' used from Lisp code
That command is designed for interactive use only

In scroll-one-up:
SmoothScroll.el:16 :4 :Warning: `next-line' used from Lisp code
## That command is designed for interactive use only
